### PR TITLE
fix(docs): Restore details/summary rendering in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,6 @@
    </ul>	   
   </details>
   <details>
-  <p></p>
       <summary><b>Save Image 🔔ED</b></summary>
   <ul>
   <p></p>
@@ -547,7 +546,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>LoRA Stacker 💬ED</b></summary>
   <ul>
     <p></p>
@@ -570,7 +568,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Embedding Stacker 💬ED</b></summary>
   <ul>
     <p></p>
@@ -586,7 +583,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Wildcard Encode 💬ED</b></summary>
   <ul>
     <p></p>
@@ -606,7 +602,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>TIPO Script 💬ED</b></summary>
   <ul>
     <p></p>
@@ -619,7 +614,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Regional Stacker 💬ED, Regional Script 💬ED</b></summary>
   <ul>
     <p></p>
@@ -632,7 +626,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Refiner Script 💬ED</b></summary>
   <ul>
     <p></p>
@@ -646,7 +639,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Int Holder 💬ED</b></summary>
   <ul>
     <p></p>
@@ -659,8 +651,8 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>FaceDetailer 💬ED</b></summary>
+  <ul>
     <p></p>
     <p align="left">
     <img src="https://github.com/jags111/efficiency-nodes-comfyui/assets/43065065/3c79367f-e2f7-4f3c-bffe-48be9a6627c9" width="250">
@@ -670,7 +662,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>MaskDetailer 💬ED</b></summary>
   <ul>
     <p></p>
@@ -682,7 +673,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Detailer (SEGS) 💬ED</b></summary>
   <ul>
     <p></p>
@@ -694,7 +684,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Ultimate SD Upscale 💬ED</b></summary>
   <ul>
     <p></p>
@@ -706,7 +695,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>SUPIR 💬ED</b></summary>
   <ul>
     <p></p>

--- a/README_KR.md
+++ b/README_KR.md
@@ -539,7 +539,6 @@
   </ul>
   </details>
   <details>
-  <p></p>
       <summary><b>Save Image 🔔ED</b></summary>
   <ul>
   <p></p>
@@ -555,7 +554,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>LoRA Stacker 💬ED</b></summary>
   <ul>
     <p></p>
@@ -579,7 +577,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Embedding Stacker 💬ED</b></summary>
   <ul>
     <p></p>
@@ -597,7 +594,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Wildcard Encode 💬ED</b></summary>
   <ul>
     <p></p>
@@ -617,7 +613,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>TIPO Script 💬ED</b></summary>
   <ul>
     <p></p>
@@ -630,7 +625,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Regional Stacker 💬ED, Regional Script 💬ED</b></summary>
   <ul>
     <p></p>
@@ -643,7 +637,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Refiner Script 💬ED</b></summary>
   <ul>
     <p></p>
@@ -657,7 +650,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Int Holder 💬ED</b></summary>
   <ul>
     <p></p>
@@ -670,7 +662,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>FaceDetailer 💬ED</b></summary>
   <ul>
     <p></p>
@@ -689,7 +680,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>MaskDetailer 💬ED</b></summary>
   <ul>
     <p></p>
@@ -702,7 +692,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Detailer (SEGS) 💬ED</b></summary>
   <ul>
     <p></p>
@@ -715,7 +704,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>Ultimate SD Upscale 💬ED</b></summary>
   <ul>
     <p></p>
@@ -728,7 +716,6 @@
   </ul>
   </details>
   <details>
-    <p></p>
     <summary><b>SUPIR 💬ED</b></summary>
   <ul>
     <p></p>


### PR DESCRIPTION
## Problem

In the `💬ED Node Descriptions` section of both `README.md` and `README_KR.md`, several nodes render incorrectly on GitHub: some show as plain "Details" instead of their node names, and four nodes have broken list indentation.

### Symptom 1: 13 nodes rendered as "Details"

The 13 collapsible sections from `Save Image 🔔ED` through `SUPIR 💬ED` display the default fallback text "Details" instead of their actual node names.

### Symptom 2: Broken indentation after FaceDetailer (README.md only)

`MaskDetailer`, `Detailer (SEGS)`, `Ultimate SD Upscale`, and `SUPIR` are rendered with shallower indentation than the preceding nodes.

## Cause

### Symptom 1

The affected 13 `<details>` blocks contain an empty `<p></p>` placed before `<summary>`. Per the HTML spec, `<summary>` must be the first child of `<details>`; otherwise the browser ignores it and falls back to the default "Details" label.

The first 4 nodes (Efficient Loader, KSampler, Inpaint Mode, Load Image) do not have this issue and render correctly.

### Symptom 2

The `FaceDetailer 💬ED` section in `README.md` is missing its opening `<ul>` tag, leaving the closing `</ul>` without a matching open. This breaks list nesting for the subsequent nodes.

## Visual Comparison

### README.md

| Before | After |
|---|---|
|<img width="1138" height="744" alt="image" src="https://github.com/user-attachments/assets/4108f3b8-e70c-411a-80a2-51f451466bd1" /> | <img src="https://github.com/user-attachments/assets/72971ec0-c4be-44aa-baf7-c68f7a3323b1" /> |

### README_KR.md

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/f7d861f5-9103-4282-956f-04311b616a50" /> | <img src="https://github.com/user-attachments/assets/35ada420-4def-44e5-9c94-c93eb35266c2" /> |

## Changes

- `README.md`: Removed 13 invalid `<p></p>` elements + added the missing `<ul>` opening tag in the FaceDetailer section
- `README_KR.md`: Removed 13 invalid `<p></p>` elements

No content or functional changes.